### PR TITLE
Updating repo name from gh-contributions to github-contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,19 +6,19 @@ A simple application that generates a repository that being added into your GitH
 Installation
 ------------
 
-    wget -qO- https://raw.github.com/IonicaBizau/gh-contributions/master/installer.sh | sh
+    wget -qO- https://raw.github.com/IonicaBizau/github-contributions/master/installer.sh | sh
 
 If your system does not have _wget_, you can also use _curl_:
 
-    curl https://raw.github.com/IonicaBizau/gh-contributions/master/installer.sh | sh
+    curl https://raw.github.com/IonicaBizau/github-contributions/master/installer.sh | sh
 
 Usage
 -----
 
-The installer script will create a folder in `home` called `gh-contributions`. So enter in that folder (`cd ~/gh-contributions`) and run `node server` or directly:
+The installer script will create a folder in `home` called `github-contributions`. So enter in that folder (`cd ~/github-contributions`) and run `node server` or directly:
 
 ```
-node ~/gh-contributions/server.js
+node ~/github-contributions/server.js
 ```
 
 The application runs on the port `9000`. Open your browser at `http://localhost:9000/` there you will see the contribution designer. You will draw the commits. A JSON object is generated:

--- a/installer.sh
+++ b/installer.sh
@@ -1,19 +1,19 @@
 echo "Welcome to Github contributions!"
 sleep 2
-echo "Making gh-contributions directory in ~/"
-rm -rf ~/gh-contributions
-mkdir ~/gh-contributions
-echo "... entering ~/gh-contributions"
-cd ~/gh-contributions
+echo "Making github-contributions directory in ~/"
+rm -rf ~/github-contributions
+mkdir ~/github-contributions
+echo "... entering ~/github-contributions"
+cd ~/github-contributions
 
 echo "... downloading"
 # If wget is not present, use curl.
-wget https://github.com/IonicaBizau/gh-contributions/archive/master.zip || curl -OL https://github.com/IonicaBizau/gh-contributions/archive/master.zip
+wget https://github.com/IonicaBizau/github-contributions/archive/master.zip || curl -OL https://github.com/IonicaBizau/github-contributions/archive/master.zip
 
 echo "... unzipping"
 unzip master.zip
 mv github-contributions-master/* ./
 npm install
 rm -rf github-contributions-master master.zip
-echo "Sucessfully installed. Please type: cd ~/gh-contributions"
+echo "Sucessfully installed. Please type: cd ~/github-contributions"
 echo "Bye!"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/IonicaBizau/gh-contributions.git"
+    "url": "git://github.com/IonicaBizau/github-contributions.git"
   },
   "keywords": [
     "contributions",
@@ -26,11 +26,11 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/IonicaBizau/gh-contributions/issues"
+    "url": "https://github.com/IonicaBizau/github-contributions/issues"
   },
   "scripts": {
     "start": "node server.js"
   },
-  "homepage": "https://github.com/IonicaBizau/gh-contributions",
+  "homepage": "https://github.com/IonicaBizau/github-contributions",
   "devDependencies": {}
 }


### PR DESCRIPTION
Some files were still referencing the old repo name. This updates them.
