### PR TITLE
Revert custom JSON.stringify to fix the app in Firefox

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -302,23 +302,10 @@ $(function () {
  *
  */
 function generateData(coordinates) {
-    var lines = [
-        '{',
-        '    "coordinates": ['
-    ];
-
-    for (var i = 0; i < coordinates.length; i++) {
-        var c = coordinates[i];
-        lines.push('        { "x": ' + c.x
-            + ', "y": ' + c.y
-            + (i == coordinates.length - 1 ? ' }' : ' },'));
-    }
-
-    lines.push('    ],');
-    lines.push('    "commitsPerDay": 2');
-    lines.push('}');
-
-    return lines.join('\n');
+    return JSON.stringify({
+        coordinates: coordinates,
+        commitsPerDay: 2
+    }, null, 4);
 }
 
 /**


### PR DESCRIPTION
The fancy stuff I did in 2a7c41c doesn't work in Firefox :( it generates
"double-stringified" data like this:

```
"{\n    \"coordinates\": [\n        {\n            \"x\": 8,\n
\"y\": 4\n        }\n    ],\n    \"commitsPerDay\": 2\n}"
```

:poop:
