### PR TITLE
Fix GitHub timezone issue

### DIFF
--- a/contributions.js
+++ b/contributions.js
@@ -69,7 +69,7 @@ module.exports = {
         for (var i = 0; i < 366; ++i) {
 
             // get the unix stamp
-            if (dateObj < new Date(2014, 2, 10)) { // Before Mar 10, 2014, GitHub treat commit date in UTC -8 timezone.
+            if (dateObj < new Date(2014, 2, 10)) { // Before Mar 10, 2014, GitHub treats commit date in UTC−08:00 timezone.
               var timezoneOffset = -8 * 60 + dateObj.getTimezoneOffset();
               var unixStamp = dateObj.getTime() / 1000 - timezoneOffset * 60;
             } else {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "Guilherme Sad <gorgulhoguilherme@gmail.com>",
     "ComFreek <comfreek@outlook.com>",
     "Adrian Moisey <adrian@changeover.za.net>",
-    "James Nylen <jnylen@gmail.com>"
+    "James Nylen <jnylen@gmail.com>",
+    "Sin <dev@zouxin.net>"
   ],
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
According to the following article from GitHub blog:
[Timezone-aware contribution graphs](https://github.com/blog/1793-timezone-aware-contribution-graphs)
after Monday 10 March 2014, when counting commits, they use the timezone information present in the timestamps for those commits.
But before Monday 10 March 2014, they use the server timezone which is UTC-8 (got that info from google). In this commit the date before Monday 10 March 2014 is adjusted to fit the situation.
fix #17
